### PR TITLE
Add using H2 in mem db, Spring Data Rest poc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,21 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
-		<!-- With this dependency there is a startup exception
-		due to missing DB configuration details -->
-		<!-- <dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency> -->
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-rest</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/com/devature/penguin_api/PenguinApiApplication.java
+++ b/src/main/java/com/devature/penguin_api/PenguinApiApplication.java
@@ -23,6 +23,8 @@ public class PenguinApiApplication {
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
 						.allowedOrigins(clientOrigin)
+						.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
 						.allowCredentials(true);
 			}
 		};

--- a/src/main/java/com/devature/penguin_api/config/SpringDataRestCustomization.java
+++ b/src/main/java/com/devature/penguin_api/config/SpringDataRestCustomization.java
@@ -1,0 +1,29 @@
+package com.devature.penguin_api.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+
+// Spring Data REST CORS configuration
+@Component
+public class SpringDataRestCustomization implements RepositoryRestConfigurer {
+    @Autowired
+    Environment environment;
+
+    @Override
+    public void configureRepositoryRestConfiguration(
+            RepositoryRestConfiguration config,
+            CorsRegistry registry) {
+
+        String clientOrigin = environment.getProperty("clientOrigin");
+
+        registry.addMapping("/**")
+						.allowedOrigins(clientOrigin)
+						.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+						.allowCredentials(true);
+    }
+}

--- a/src/main/java/com/devature/penguin_api/controller/RootController.java
+++ b/src/main/java/com/devature/penguin_api/controller/RootController.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 @RestController
 public class RootController {
 
-    @GetMapping("/")
+    @GetMapping("/api/test")
     public Map<String, Object> getRootData() {
         Map<String, Object> response = new HashMap<>();
         response.put("message", "Welcome to Penguin API");

--- a/src/main/java/com/devature/penguin_api/model/Work.java
+++ b/src/main/java/com/devature/penguin_api/model/Work.java
@@ -1,0 +1,24 @@
+package com.devature.penguin_api.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Work {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String title;
+    private String description;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/devature/penguin_api/repository/WorkRepository.java
+++ b/src/main/java/com/devature/penguin_api/repository/WorkRepository.java
@@ -1,0 +1,16 @@
+package com.devature.penguin_api.repository;
+
+import com.devature.penguin_api.model.Work;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+@RepositoryRestResource()
+@CrossOrigin
+public interface WorkRepository extends
+                                    PagingAndSortingRepository<Work, Long>,
+                                    CrudRepository<Work, Long> {
+    
+}


### PR DESCRIPTION
Adds packages to pom.xml for H2 in memory database and Spring Data (REST repositories)
Configuration class to configure CORS for the REST repositories, which aren't covered by the global configuration