### PR TITLE
Adding functionality to issue and verify JWT tokens

### DIFF
--- a/src/main/java/dev/devature/penguin_api/config/SecurityConfig.java
+++ b/src/main/java/dev/devature/penguin_api/config/SecurityConfig.java
@@ -64,19 +64,11 @@ public class SecurityConfig {
     }
 
     /**
-     * Do not use this is just a test.
-     * @param subject Take in a name of the user to produce a session token.
-     * @return A {@code String} token that the user will use.
+     * Builds the secret key to be used for signing and verifying JWT tokens.
+     * @return A {@code SecretKey} to be used for signing and verifying JWT tokens.
      */
-    public String createJWTToken(String issuer, String subject, Long id){
-        SecretKey key = Jwts.SIG.HS256.key().build();
-
-        return  Jwts.builder()
-                .issuer(issuer)
-                .subject(subject)
-                .issuedAt(new Date())
-                .id(id.toString())
-                .signWith(key)
-                .compact();
+    @Bean
+    public SecretKey secretKey() {
+        return Jwts.SIG.HS256.key().build();
     }
 }

--- a/src/main/java/dev/devature/penguin_api/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/dev/devature/penguin_api/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,47 @@
+package dev.devature.penguin_api.interceptor;
+
+import dev.devature.penguin_api.service.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Component
+public class AuthenticationInterceptor implements HandlerInterceptor {
+    private static final Set<String> OPEN_ENDPOINTS;
+
+    static {
+        OPEN_ENDPOINTS = new HashSet<>();
+        OPEN_ENDPOINTS.add("/api/v1/user/registration");
+        OPEN_ENDPOINTS.add("/api/v1/user/login");
+    }
+
+    private final JwtService jwtService;
+
+    @Autowired
+    public AuthenticationInterceptor(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (request.getMethod().equals("OPTIONS")) return true;
+        if (OPEN_ENDPOINTS.contains(request.getRequestURI())) return true;
+
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            response.sendError(401, "Invalid authorization header");
+            return false;
+        }
+
+        String token = authorizationHeader.substring("Bearer ".length());
+        if (this.jwtService.verifyToken(token).isPresent()) return true;
+        else response.sendError(401, "Invalid authorization token");
+
+        return false;
+    }
+}

--- a/src/main/java/dev/devature/penguin_api/repository/UserRepository.java
+++ b/src/main/java/dev/devature/penguin_api/repository/UserRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RegisterRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long> {
 
 
     /**

--- a/src/main/java/dev/devature/penguin_api/service/JwtService.java
+++ b/src/main/java/dev/devature/penguin_api/service/JwtService.java
@@ -1,0 +1,53 @@
+package dev.devature.penguin_api.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class JwtService {
+    private final SecretKey secretKey;
+    private final JwtParser jwtParser;
+
+    @Value("${jwt.defaultTTLSeconds}")
+    private int defaultTTLSeconds;
+
+    @Autowired
+    public JwtService(SecretKey secretKey) {
+        this.secretKey = secretKey;
+        this.jwtParser = Jwts.parser().verifyWith(secretKey).build();
+    }
+
+    public Optional<Claims> verifyToken(String token) {
+        try {
+            return Optional.of(this.jwtParser.parseSignedClaims(token).getPayload());
+        } catch (JwtException | IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    public String generateToken(String subject) {
+        return this.generateToken(subject, null);
+    }
+
+    public String generateToken(String subject, Map<String, ?> claims) {
+        return Jwts.builder()
+                .subject(subject)
+                .claims(claims)
+                .issuer("Ticket Penguin")
+                .issuedAt(Date.from(Instant.now()))
+                .expiration(Date.from(Instant.now().plusSeconds(defaultTTLSeconds)))
+                .signWith(this.secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/dev/devature/penguin_api/service/RegisterService.java
+++ b/src/main/java/dev/devature/penguin_api/service/RegisterService.java
@@ -2,7 +2,7 @@ package dev.devature.penguin_api.service;
 
 import dev.devature.penguin_api.config.SecurityConfig;
 import dev.devature.penguin_api.entity.User;
-import dev.devature.penguin_api.repository.RegisterRepository;
+import dev.devature.penguin_api.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,16 +12,17 @@ import java.util.regex.Pattern;
 @Service
 @Transactional
 public class RegisterService {
-    private final RegisterRepository registerRepository;
+    private static final String passwordRegex = "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[~`!@#$%^&*()\\-_+={}\\[\\]|;:<>,./?]).{8,}$";
+    private static final String emailRegex = "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])";
+
+    private final UserRepository userRepository;
     private final SecurityConfig securityConfig;
-    private final String passwordRegex = "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[~`!@#$%^&*()\\-_+={}\\[\\]|;:<>,./?]).{8,}$";
-    private final String emailRegex = "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])";
     private final Pattern passPattern;
     private final Pattern emailPattern;
 
     @Autowired
-    public RegisterService(RegisterRepository registerRepository, SecurityConfig securityConfig) {
-        this.registerRepository = registerRepository;
+    public RegisterService(UserRepository userRepository, SecurityConfig securityConfig) {
+        this.userRepository = userRepository;
         this.securityConfig = securityConfig;
 
         passPattern = Pattern.compile(passwordRegex);
@@ -50,7 +51,7 @@ public class RegisterService {
         String hashedPassword = securityConfig.passwordEncoder().encode(saltedPassword);
         user.setPassword(hashedPassword);
 
-        return registerRepository.save(user);
+        return userRepository.save(user);
     }
 
     /**
@@ -78,7 +79,7 @@ public class RegisterService {
      * @return Return {@code True} if email does not available or {@code False} if the email is unavailable.
      */
     public boolean checkEmailAvailable(String email){
-        User user = registerRepository.findByEmail(email);
+        User user = userRepository.findByEmail(email);
         return user == null;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,5 @@ argon2.hashLength=32
 argon2.parallelism=1
 argon2.memory=65536
 argon2.iterations=4
+
+jwt.defaultTTLSeconds=1800


### PR DESCRIPTION
This change adds the `JwtService`, in charge of issuing and verifying signed JWT tokens. Tokens issued are valid for 30 minutes before they expire. It also adds the `AuthenticationInterceptor`, which will intercept incoming requests and verify that they contain a valid JWT token in the request's authorization header, unless they are listed as an open endpoint.