### PR TITLE
Returning JWT after successful logins

### DIFF
--- a/src/main/java/dev/devature/penguin_api/config/SecurityConfig.java
+++ b/src/main/java/dev/devature/penguin_api/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import javax.crypto.SecretKey;
@@ -59,7 +60,7 @@ public class SecurityConfig {
      * @return Returns a new Argon2 password encoders with all the preset.
      */
     @Bean
-    public Argon2PasswordEncoder passwordEncoder(){
+    public PasswordEncoder passwordEncoder(){
         return new Argon2PasswordEncoder(saltLength, hashLength, parallelism, memory, iterations);
     }
 

--- a/src/main/java/dev/devature/penguin_api/controller/LoginController.java
+++ b/src/main/java/dev/devature/penguin_api/controller/LoginController.java
@@ -1,6 +1,7 @@
 package dev.devature.penguin_api.controller;
 
 import dev.devature.penguin_api.entity.User;
+import dev.devature.penguin_api.model.JwtToken;
 import dev.devature.penguin_api.service.LoginService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -27,15 +28,10 @@ public class LoginController {
      * @return a 200 response if successful or 401 response if not
      */
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody User user) {
-
-        boolean isValid = loginService.checkValidity(user);
-        if (!isValid) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid credentials");
-
-        boolean isAuthenticated = loginService.authenticate(user);
-
-        return isAuthenticated ? ResponseEntity.ok("Login successful") :
-                ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid credentials");
+    public ResponseEntity<JwtToken> login(@RequestBody User user) {
+        JwtToken jwtToken = loginService.authenticate(user);
+        return jwtToken != null ? ResponseEntity.ok(jwtToken) :
+                ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
 
 

--- a/src/main/java/dev/devature/penguin_api/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/dev/devature/penguin_api/interceptor/AuthenticationInterceptor.java
@@ -1,5 +1,6 @@
 package dev.devature.penguin_api.interceptor;
 
+import dev.devature.penguin_api.model.JwtToken;
 import dev.devature.penguin_api.service.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -38,7 +39,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             return false;
         }
 
-        String token = authorizationHeader.substring("Bearer ".length());
+        JwtToken token = new JwtToken(authorizationHeader.substring("Bearer ".length()));
         if (this.jwtService.verifyToken(token).isPresent()) return true;
         else response.sendError(401, "Invalid authorization token");
 

--- a/src/main/java/dev/devature/penguin_api/model/JwtToken.java
+++ b/src/main/java/dev/devature/penguin_api/model/JwtToken.java
@@ -1,0 +1,3 @@
+package dev.devature.penguin_api.model;
+
+public record JwtToken(String token) {}

--- a/src/main/java/dev/devature/penguin_api/service/JwtService.java
+++ b/src/main/java/dev/devature/penguin_api/service/JwtService.java
@@ -1,5 +1,6 @@
 package dev.devature.penguin_api.service;
 
+import dev.devature.penguin_api.model.JwtToken;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.JwtParser;
@@ -28,26 +29,26 @@ public class JwtService {
         this.jwtParser = Jwts.parser().verifyWith(secretKey).build();
     }
 
-    public Optional<Claims> verifyToken(String token) {
+    public Optional<Claims> verifyToken(JwtToken token) {
         try {
-            return Optional.of(this.jwtParser.parseSignedClaims(token).getPayload());
+            return Optional.of(this.jwtParser.parseSignedClaims(token.token()).getPayload());
         } catch (JwtException | IllegalArgumentException e) {
             return Optional.empty();
         }
     }
 
-    public String generateToken(String subject) {
+    public JwtToken generateToken(String subject) {
         return this.generateToken(subject, null);
     }
 
-    public String generateToken(String subject, Map<String, ?> claims) {
-        return Jwts.builder()
+    public JwtToken generateToken(String subject, Map<String, ?> claims) {
+        return new JwtToken(Jwts.builder()
                 .subject(subject)
                 .claims(claims)
                 .issuer("Ticket Penguin")
                 .issuedAt(Date.from(Instant.now()))
                 .expiration(Date.from(Instant.now().plusSeconds(defaultTTLSeconds)))
                 .signWith(this.secretKey)
-                .compact();
+                .compact());
     }
 }

--- a/src/main/java/dev/devature/penguin_api/service/RegisterService.java
+++ b/src/main/java/dev/devature/penguin_api/service/RegisterService.java
@@ -1,32 +1,23 @@
 package dev.devature.penguin_api.service;
 
-import dev.devature.penguin_api.config.SecurityConfig;
 import dev.devature.penguin_api.entity.User;
 import dev.devature.penguin_api.repository.UserRepository;
+import dev.devature.penguin_api.utils.EmailPasswordValidationUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.regex.Pattern;
 
 @Service
 @Transactional
 public class RegisterService {
-    private static final String passwordRegex = "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[~`!@#$%^&*()\\-_+={}\\[\\]|;:<>,./?]).{8,}$";
-    private static final String emailRegex = "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])";
-
     private final UserRepository userRepository;
-    private final SecurityConfig securityConfig;
-    private final Pattern passPattern;
-    private final Pattern emailPattern;
+    private final PasswordEncoder passwordEncoder;
 
     @Autowired
-    public RegisterService(UserRepository userRepository, SecurityConfig securityConfig) {
+    public RegisterService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
-        this.securityConfig = securityConfig;
-
-        passPattern = Pattern.compile(passwordRegex);
-        emailPattern = Pattern.compile(emailRegex);
+        this.passwordEncoder = passwordEncoder;
     }
 
     /**
@@ -35,38 +26,18 @@ public class RegisterService {
      * {@code null} if it failed to add or meet requirements.
      */
     public User registerUser(User user){
-        boolean isEmailValid = checkEmailRequirements(user.getEmail());
-        boolean isPasswordValid = checkPasswordRequirements(user.getPassword());
+        boolean isEmailValid = EmailPasswordValidationUtils.isValidEmail(user.getEmail());
+        boolean isPasswordValid = EmailPasswordValidationUtils.isValidPassword(user.getPassword());
         boolean isEmailAvailable = checkEmailAvailable(user.getEmail());
 
         if(!isEmailValid || !isPasswordValid || !isEmailAvailable){
             return null;
         }
 
-        String hashedPassword = securityConfig.passwordEncoder().encode(user.getPassword());
+        String hashedPassword = this.passwordEncoder.encode(user.getPassword());
         user.setPassword(hashedPassword);
 
         return userRepository.save(user);
-    }
-
-    /**
-     * This is based on the RFC 5322 requirements for email.
-     * @param email Takes in a  {@code String} email to be processed.
-     * @return A {@code True} if the password meets requirements or {@code False} if it fails to
-     * meet the requirements.
-     */
-    public boolean checkEmailRequirements(String email){
-        return emailPattern.matcher(email).matches();
-    }
-
-    /**
-     * This is based on 1 uppercase, 1 lowercase, 1 special, 1 number, and 8 characters or greater.
-     * @param password Take in {@code String} object password.
-     * @return A {@code True} if the password meets requirements or {@code False} if it fails to
-     * meet the requirements.
-     */
-    public boolean checkPasswordRequirements(String password){
-        return passPattern.matcher(password).matches();
     }
 
     /**

--- a/src/main/java/dev/devature/penguin_api/utils/EmailPasswordValidationUtils.java
+++ b/src/main/java/dev/devature/penguin_api/utils/EmailPasswordValidationUtils.java
@@ -9,10 +9,22 @@ public class EmailPasswordValidationUtils {
     private static final Pattern passPattern = Pattern.compile(PASSWORD_REGEX);
     private static final Pattern emailPattern = Pattern.compile(EMAIL_REGEX);
 
+    /**
+     * This is based on the RFC 5322 requirements for email.
+     * @param email Takes in a  {@code String} email to be processed.
+     * @return {@code True} if the password meets requirements or {@code False} if it fails to
+     * meet the requirements.
+     */
     public static boolean isValidEmail(String email) {
         return emailPattern.matcher(email).matches();
     }
 
+    /**
+     * This is based on 1 uppercase, 1 lowercase, 1 special, 1 number, and 8 characters or greater.
+     * @param password Take in {@code String} object password.
+     * @return {@code True} if the password meets requirements or {@code False} if it fails to
+     * meet the requirements.
+     */
     public static boolean isValidPassword(String password) {
         return passPattern.matcher(password).matches();
     }

--- a/src/test/java/dev/devature/penguin_api/controller/LoginControllerTest.java
+++ b/src/test/java/dev/devature/penguin_api/controller/LoginControllerTest.java
@@ -1,6 +1,7 @@
 package dev.devature.penguin_api.controller;
 
 import dev.devature.penguin_api.entity.User;
+import dev.devature.penguin_api.model.JwtToken;
 import dev.devature.penguin_api.service.LoginService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,8 +29,10 @@ class LoginControllerTest extends RequestsTest {
         User user = new User("agoodtestemail@testemail.com","Th1sisvalidpass!");
         String userJson = objectMapper.writeValueAsString(user);
 
-        when(loginService.checkValidity(user)).thenReturn(true);
-        when(loginService.authenticate(user)).thenReturn(true);
+        JwtToken jwtToken = new JwtToken("abc123");
+        String jwtTokenJson = objectMapper.writeValueAsString(jwtToken);
+
+        when(loginService.authenticate(user)).thenReturn(jwtToken);
 
         this.mockMvc.perform(post("/api/v1/user/login")
                         .with(csrf())
@@ -37,7 +40,7 @@ class LoginControllerTest extends RequestsTest {
                         .content(userJson))
                 .andExpect(status().is(200))
                 .andExpect(content()
-                        .string(containsString("Login successful")))
+                        .string(containsString(jwtTokenJson)))
                 .andDo(document("login/success"));
     }
 
@@ -46,16 +49,13 @@ class LoginControllerTest extends RequestsTest {
         User user = new User("testemail2testemail.com", "invalid");
         String userJson = objectMapper.writeValueAsString(user);
 
-        when(loginService.checkValidity(user)).thenReturn(true);
-        when(loginService.authenticate(user)).thenReturn(false);
+        when(loginService.authenticate(user)).thenReturn(null);
 
         this.mockMvc.perform(post("/api/v1/user/login")
                         .with(csrf())
                         .contentType("application/json")
                         .content(userJson))
                 .andExpect(status().is(401))
-                .andExpect(content()
-                        .string(containsString("Invalid credentials")))
                 .andDo(document("login/failure"));
     }
 }

--- a/src/test/java/dev/devature/penguin_api/service/EmailPasswordValidationUtilsTest.java
+++ b/src/test/java/dev/devature/penguin_api/service/EmailPasswordValidationUtilsTest.java
@@ -1,29 +1,12 @@
 package dev.devature.penguin_api.service;
 
-import dev.devature.penguin_api.entity.User;
+import dev.devature.penguin_api.utils.EmailPasswordValidationUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 
-public class RegisterServiceTest {
-
-    @Mock
-    private User user;
-
-    @InjectMocks
-    private RegisterService registerService;
-
-    @BeforeEach
-    public void setup() throws InterruptedException {
-
-        MockitoAnnotations.openMocks(this);
-    }
-
+public class EmailPasswordValidationUtilsTest {
     @Test
     public void emailRequirementTest(){
         String[] email = {"normal@example.com", "first.last@example.com", "user+tag@example.com",
@@ -33,7 +16,7 @@ public class RegisterServiceTest {
         boolean[] actualResult = new boolean[10];
 
         for(int i = 0; i < email.length; ++i){
-            actualResult[i] = registerService.checkEmailRequirements(email[i]);
+            actualResult[i] = EmailPasswordValidationUtils.isValidEmail(email[i]);
         }
 
         Assertions.assertArrayEquals(expectedResult, actualResult,
@@ -51,7 +34,7 @@ public class RegisterServiceTest {
 
         // When
         for(int i = 0; i < password.length; ++i){
-            actualResult[i] = registerService.checkPasswordRequirements(password[i]);
+            actualResult[i] = EmailPasswordValidationUtils.isValidPassword(password[i]);
         }
 
         // Then

--- a/src/test/java/dev/devature/penguin_api/service/LoginServiceTest.java
+++ b/src/test/java/dev/devature/penguin_api/service/LoginServiceTest.java
@@ -8,9 +8,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import dev.devature.penguin_api.model.JwtToken;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class LoginServiceTest {
@@ -23,6 +23,9 @@ class LoginServiceTest {
 
     @Mock
     private Argon2PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtService jwtService;
 
 
     @BeforeEach
@@ -50,28 +53,28 @@ class LoginServiceTest {
 
         User mockUser = new User("test@example.com", hashedPassword);
         when(userRepository.findByEmail(user.getEmail())).thenReturn(mockUser);
-
         when(passwordEncoder.matches(user.getPassword(), hashedPassword)).thenReturn(true);
+        when(jwtService.generateToken(mockUser.getEmail())).thenReturn(new JwtToken("abc123"));
 
-        boolean result = loginService.authenticate(user);
+        JwtToken result = loginService.authenticate(user);
 
-        assertTrue(result);
+        assertNotNull(result);
         verify(userRepository).findByEmail(user.getEmail());
         verify(passwordEncoder).matches(user.getPassword(), hashedPassword);
     }
 
     @Test
     void testAuthenticate_Failure_InvalidPassword() {
-        User user = new User("test@example.com", "invalid");
+        User user = new User("test@example.com", "invalidP@ssw0rd!");
         String hashedPassword = "$argon2id$v=19$m=65536,t=3,p=4$...";
 
         User mockUser = new User("test@example.com", hashedPassword);
         when(userRepository.findByEmail(user.getEmail())).thenReturn(mockUser);
         when(passwordEncoder.matches(user.getPassword(), hashedPassword)).thenReturn(false);
 
-        boolean result = loginService.authenticate(user);
+        JwtToken result = loginService.authenticate(user);
 
-        assertFalse(result);
+        assertNull(result);
         verify(userRepository).findByEmail(user.getEmail());
         verify(passwordEncoder).matches(user.getPassword(), hashedPassword);
     }
@@ -80,13 +83,13 @@ class LoginServiceTest {
 
     @Test
     void testAuthenticate_Failure_UserNotFound() {
-        User user = new User("notfound@example.com", "SomePassword");
+        User user = new User("notfound@example.com", "SomeP@ssw0rd!");
 
         when(userRepository.findByEmail(user.getEmail())).thenReturn(null);
 
-        boolean result = loginService.authenticate(user);
+        JwtToken result = loginService.authenticate(user);
 
-        assertFalse(result);
+        assertNull(result);
         verify(userRepository).findByEmail(user.getEmail());
     }
 


### PR DESCRIPTION
This PR changes the behavior of the `LoginController` and `LoginService` to return a JWT Token after a user successfully authenticates with the API. The client can then use this JWT token to authenticate during subsequent requests. Some light code refactoring is also included in this PR.