### PR TITLE
Fixed CORS to include www since that is primary, and fix Azure App log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,12 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.6.0</version>
 		</dependency>
+
+		<!-- Logger for Azure -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-logging</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/dev/devature/penguin_api/config/ServerConfiguration.java
+++ b/src/main/java/dev/devature/penguin_api/config/ServerConfiguration.java
@@ -1,6 +1,7 @@
 package dev.devature.penguin_api.config;
 
 import dev.devature.penguin_api.interceptor.AuthenticationInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -9,7 +10,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class ServerConfiguration implements WebMvcConfigurer {
-
     private final Environment env;
     private final AuthenticationInterceptor authInterceptor;
 
@@ -21,9 +21,13 @@ public class ServerConfiguration implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         String clientOrigin = this.env.getProperty("clientOrigin");
+        String clientOrigin2 = this.env.getProperty("clientOrigin2");
 
         registry.addMapping("/**")
-                .allowedOrigins(clientOrigin)
+                .allowedOrigins(
+                        clientOrigin,
+                        clientOrigin2
+                )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/dev/devature/penguin_api/config/SpringDataRestCustomization.java
+++ b/src/main/java/dev/devature/penguin_api/config/SpringDataRestCustomization.java
@@ -19,9 +19,13 @@ public class SpringDataRestCustomization implements RepositoryRestConfigurer {
             CorsRegistry registry) {
 
         String clientOrigin = environment.getProperty("clientOrigin");
+        String clientOrigin2 = environment.getProperty("clientOrigin2");
 
         registry.addMapping("/**")
-						.allowedOrigins(clientOrigin)
+						.allowedOrigins(
+                                clientOrigin,
+                                clientOrigin2
+                        )
 						.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*")
 						.allowCredentials(true);

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,4 +1,5 @@
-clientOrigin=https://devature.dev
+clientOrigin=https://www.devature.dev
+clientOrigin2=https://devature.dev
 
 # Injected on CICD - Don't fill these in.
 spring.datasource.url=

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Since the primarily domain is not devature.dev, but instead www.devature.dev. I added the www and made it the top clientorigin. All request from devature.dev redirects to www.deveture.dev, but also since Azure requires devature.dev I included it to CORS. Also fixing the logging that the App Service expects with starter-logging.